### PR TITLE
TOMEE-4508 - exclude jakarta el-api from cdi-api to use tomcat api instead

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -551,6 +551,10 @@
                         <groupId>jakarta.inject</groupId>
                         <artifactId>jakarta.inject-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -1013,6 +1017,10 @@
                     <groupId>jakarta.inject</groupId>
                     <artifactId>jakarta.inject-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -1024,6 +1032,10 @@
                 <exclusion>
                     <groupId>jakarta.inject</groupId>
                     <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
See [TOMEE-4508](https://issues.apache.org/jira/browse/TOMEE-4508)

newly built jakartaee-api jar now includes the tomcat el-api instead