### PR TITLE
TOMEE-4537 - Upgrade API to EE 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Cache Maven packages

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.tomee</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.2-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakartaee-api</artifactId>
 
-    <name>Apache TomEE :: Jakarta EE 10 Full API</name>
+    <name>Apache TomEE :: Jakarta EE 11 Full API</name>
 
     <properties>
         <geronimo-j2ee-connector_1.6_spec.version>1.0</geronimo-j2ee-connector_1.6_spec.version>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -75,9 +75,6 @@
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
         <jakarta.mail-api.version>2.1.0</jakarta.mail-api.version>
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
-
-        <!-- Optional APIs -->
-        <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
     </properties>
 
 
@@ -202,7 +199,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Export-Package>
-                                            jakarta.xml,jakarta.xml.ws,jakarta.xml.ws.handler,jakarta.xml.ws.handler.soap,jakarta.xml.ws.spi,jakarta.xml.ws.http,jakarta.xml.ws.soap,jakarta.xml.soap,jakarta.xml.namespace,jakarta.xml.registry,jakarta.xml.registry.infomodel,jakarta.xml.rpc,jakarta.xml.rpc.encoding,jakarta.xml.rpc.handler,jakarta.xml.rpc.handler.soap,jakarta.xml.rpc.holders,jakarta.xml.rpc.server,jakarta.xml.rpc.soap,jakarta.xml.stream,jakarta.xml.stream.events,jakarta.xml.stream.util,jakarta.xml.bind,jakarta.xml.bind.annotation,jakarta.xml.bind.annotation.adapters,jakarta.xml.bind.attachment,jakarta.xml.bind.helpers,jakarta.xml.bind.util,jakarta.annotation,jakarta.annotation.security,jakarta.ejb,jakarta.ejb.spi,jakarta.interceptor,jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.resource.spi.work,jakarta.enterprise,jakarta.enterprise.deploy,jakarta.enterprise.deploy.model,jakarta.enterprise.deploy.model.exceptions,jakarta.enterprise.deploy.shared,jakarta.enterprise.deploy.shared.factories,jakarta.enterprise.deploy.spi,jakarta.enterprise.deploy.spi.exceptions,jakarta.enterprise.deploy.spi.factories,jakarta.enterprise.deploy.spi.status,jakarta.management,jakarta.management.j2ee,jakarta.management.j2ee.statistics,jakarta.security,jakarta.security.jacc,jakarta.jms,jakarta.persistence,jakarta.persistence.spi,jakarta.transaction,jakarta.transaction.xa,jakarta.jws,jakarta.jws.soap
+                                            jakarta.xml,jakarta.xml.namespace,jakarta.xml.registry,jakarta.xml.registry.infomodel,jakarta.xml.rpc,jakarta.xml.rpc.encoding,jakarta.xml.rpc.handler,jakarta.xml.rpc.handler.soap,jakarta.xml.rpc.holders,jakarta.xml.rpc.server,jakarta.xml.rpc.soap,jakarta.xml.stream,jakarta.xml.stream.events,jakarta.xml.stream.util,jakarta.activation,jakarta.annotation,jakarta.annotation.security,jakarta.ejb,jakarta.ejb.spi,jakarta.interceptor,jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.resource.spi.work,jakarta.enterprise,jakarta.enterprise.deploy,jakarta.enterprise.deploy.model,jakarta.enterprise.deploy.model.exceptions,jakarta.enterprise.deploy.shared,jakarta.enterprise.deploy.shared.factories,jakarta.enterprise.deploy.spi,jakarta.enterprise.deploy.spi.exceptions,jakarta.enterprise.deploy.spi.factories,jakarta.enterprise.deploy.spi.status,jakarta.management,jakarta.management.j2ee,jakarta.management.j2ee.statistics,jakarta.security,jakarta.security.jacc,jakarta.jms,jakarta.persistence,jakarta.persistence.spi,jakarta.transaction,jakarta.transaction.xa,jakarta.servlet,jakarta.servlet.http,jakarta.servlet.resources,jakarta.ws.rs
                                         </Export-Package>
                                         <Import-Package>org.apache.geronimo.osgi.registry.api;resolution:=optional
                                         </Import-Package>
@@ -264,7 +261,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Export-Package>
-                                            jakarta.xml,jakarta.xml.ws,jakarta.xml.ws.handler,jakarta.xml.ws.handler.soap,jakarta.xml.ws.spi,jakarta.xml.ws.http,jakarta.xml.ws.soap,jakarta.xml.soap,jakarta.xml.namespace,jakarta.xml.registry,jakarta.xml.registry.infomodel,jakarta.xml.rpc,jakarta.xml.rpc.encoding,jakarta.xml.rpc.handler,jakarta.xml.rpc.handler.soap,jakarta.xml.rpc.holders,jakarta.xml.rpc.server,jakarta.xml.rpc.soap,jakarta.xml.stream,jakarta.xml.stream.events,jakarta.xml.stream.util,jakarta.xml.bind,jakarta.xml.bind.annotation,jakarta.xml.bind.annotation.adapters,jakarta.xml.bind.attachment,jakarta.xml.bind.helpers,jakarta.xml.bind.util,jakarta.activation,jakarta.annotation,jakarta.annotation.security,jakarta.ejb,jakarta.ejb.spi,jakarta.interceptor,jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.resource.spi.work,jakarta.enterprise,jakarta.enterprise.deploy,jakarta.enterprise.deploy.model,jakarta.enterprise.deploy.model.exceptions,jakarta.enterprise.deploy.shared,jakarta.enterprise.deploy.shared.factories,jakarta.enterprise.deploy.spi,jakarta.enterprise.deploy.spi.exceptions,jakarta.enterprise.deploy.spi.factories,jakarta.enterprise.deploy.spi.status,jakarta.management,jakarta.management.j2ee,jakarta.management.j2ee.statistics,jakarta.security,jakarta.security.jacc,jakarta.jms,jakarta.persistence,jakarta.persistence.spi,jakarta.transaction,jakarta.transaction.xa,jakarta.servlet,jakarta.servlet.http,jakarta.servlet.resources,jakarta.jws,jakarta.ws.rs,jakarta.jws.soap
+                                            jakarta.xml,jakarta.xml.namespace,jakarta.xml.registry,jakarta.xml.registry.infomodel,jakarta.xml.rpc,jakarta.xml.rpc.encoding,jakarta.xml.rpc.handler,jakarta.xml.rpc.handler.soap,jakarta.xml.rpc.holders,jakarta.xml.rpc.server,jakarta.xml.rpc.soap,jakarta.xml.stream,jakarta.xml.stream.events,jakarta.xml.stream.util,jakarta.activation,jakarta.annotation,jakarta.annotation.security,jakarta.ejb,jakarta.ejb.spi,jakarta.interceptor,jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.resource.spi.work,jakarta.enterprise,jakarta.enterprise.deploy,jakarta.enterprise.deploy.model,jakarta.enterprise.deploy.model.exceptions,jakarta.enterprise.deploy.shared,jakarta.enterprise.deploy.shared.factories,jakarta.enterprise.deploy.spi,jakarta.enterprise.deploy.spi.exceptions,jakarta.enterprise.deploy.spi.factories,jakarta.enterprise.deploy.spi.status,jakarta.management,jakarta.management.j2ee,jakarta.management.j2ee.statistics,jakarta.security,jakarta.security.jacc,jakarta.jms,jakarta.persistence,jakarta.persistence.spi,jakarta.transaction,jakarta.transaction.xa,jakarta.servlet,jakarta.servlet.http,jakarta.servlet.resources,jakarta.ws.rs
                                         </Export-Package>
                                         <Import-Package>org.apache.geronimo.osgi.registry.api;resolution:=optional
                                         </Import-Package>
@@ -735,20 +732,6 @@
                 <optional>true</optional>
             </dependency>
 
-            <!-- Optional APIs -->
-            <dependency>
-                <groupId>jakarta.jws</groupId>
-                <artifactId>jakarta.jws-api</artifactId>
-                <version>${jakarta.jws-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.jws</groupId>
-                <artifactId>jakarta.jws-api</artifactId>
-                <version>${jakarta.jws-api.version}</version>
-                <classifier>sources</classifier>
-                <optional>true</optional>
-            </dependency>
-
             <!-- APIs from Tomcat -->
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
@@ -1168,18 +1151,6 @@
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch-api</artifactId>
-            <classifier>sources</classifier>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Optional APIs -->
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
             <classifier>sources</classifier>
             <optional>true</optional>
         </dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,48 +38,46 @@
         <geronimo-osgi.version>1.1</geronimo-osgi.version>
 
         <!-- Web Profile -->
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
-        <jakarta.authentication-api.version>3.0.0</jakarta.authentication-api.version>
+        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
         <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
-        <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
+        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jakarta.enterprise.lang-model-api.version>4.0.1</jakarta.enterprise.lang-model-api.version>
 
         <!--
         <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>
         -->
         <jakarta.inject.version>2.0.0</jakarta.inject.version>
-        <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
+        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
         <jakarta.json-api.version>2.1.1</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>
-        <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
+        <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
+        <jakarta.security.enterprise-api.version>4.0.0</jakarta.security.enterprise-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.servlet.jsp-api.version>3.1.0</jakarta.servlet.jsp-api.version>
         <jakarta.servlet.jsp.jstl-api.version>3.0.0</jakarta.servlet.jsp.jstl-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <jakarta.websocket-api.version>2.1.0</jakarta.websocket-api.version>
-        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
+        <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
+        <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
+        <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
 
         <!-- We use servlet, jsp, jaspic, websocket, el straight from Tomcat APIs -->
-        <tomcat.version>10.1.31</tomcat.version>
+        <tomcat.version>11.0.11</tomcat.version>
 
         <!--  Full platform -->
         <geronimo-activation_2.0_spec.version>1.0.0</geronimo-activation_2.0_spec.version>
         <!--    <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>-->
-        <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
+        <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
         <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>
-        <jakarta.enterprise.concurrent-api.version>3.0.2</jakarta.enterprise.concurrent-api.version>
+        <jakarta.enterprise.concurrent-api.version>3.1.1</jakarta.enterprise.concurrent-api.version>
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
         <jakarta.mail-api.version>2.1.0</jakarta.mail-api.version>
         <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
 
         <!-- Optional APIs -->
         <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
-        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
-        <jakarta.xml.soap-api.version>3.0.0</jakarta.xml.soap-api.version>
-        <jakarta.xml.ws-api.version>4.0.0</jakarta.xml.ws-api.version>
     </properties>
 
 
@@ -607,6 +605,18 @@
                 <classifier>sources</classifier>
                 <optional>true</optional>
             </dependency>
+            <dependency>
+                <groupId>jakarta.data</groupId>
+                <artifactId>jakarta.data-api</artifactId>
+                <version>${jakarta.data-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.data</groupId>
+                <artifactId>jakarta.data-api</artifactId>
+                <version>${jakarta.data-api.version}</version>
+                <classifier>sources</classifier>
+                <optional>true</optional>
+            </dependency>
 
             <!-- Full Platform -->
             <dependency>
@@ -680,6 +690,12 @@
                 <groupId>jakarta.authorization</groupId>
                 <artifactId>jakarta.authorization-api</artifactId>
                 <version>${jakarta.authorization-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.servlet</groupId>
+                        <artifactId>jakarta.servlet-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>jakarta.authorization</groupId>
@@ -687,6 +703,12 @@
                 <version>${jakarta.authorization-api.version}</version>
                 <classifier>sources</classifier>
                 <optional>true</optional>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.servlet</groupId>
+                        <artifactId>jakarta.servlet-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise.concurrent</groupId>
@@ -715,30 +737,6 @@
 
             <!-- Optional APIs -->
             <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jakarta.xml.bind-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${jakarta.xml.bind-api.version}</version>
-                <classifier>sources</classifier>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jakarta.xml.ws-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${jakarta.xml.ws-api.version}</version>
-                <classifier>sources</classifier>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.jws</groupId>
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws-api.version}</version>
@@ -747,18 +745,6 @@
                 <groupId>jakarta.jws</groupId>
                 <artifactId>jakarta.jws-api</artifactId>
                 <version>${jakarta.jws-api.version}</version>
-                <classifier>sources</classifier>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.soap</groupId>
-                <artifactId>jakarta.xml.soap-api</artifactId>
-                <version>${jakarta.xml.soap-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.soap</groupId>
-                <artifactId>jakarta.xml.soap-api</artifactId>
-                <version>${jakarta.xml.soap-api.version}</version>
                 <classifier>sources</classifier>
                 <optional>true</optional>
             </dependency>
@@ -1071,6 +1057,16 @@
             <classifier>sources</classifier>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+            <classifier>sources</classifier>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Full Platform -->
         <dependency>
@@ -1134,12 +1130,26 @@
         <dependency>
             <groupId>jakarta.authorization</groupId>
             <artifactId>jakarta.authorization-api</artifactId>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.authorization</groupId>
             <artifactId>jakarta.authorization-api</artifactId>
             <classifier>sources</classifier>
             <optional>true</optional>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
@@ -1164,42 +1174,12 @@
 
         <!-- Optional APIs -->
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <classifier>sources</classifier>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <classifier>sources</classifier>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
-            <classifier>sources</classifier>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
             <classifier>sources</classifier>
             <optional>true</optional>
         </dependency>

--- a/api/src/main/filtered-resources/jakartaee-api-feature.xml
+++ b/api/src/main/filtered-resources/jakartaee-api-feature.xml
@@ -51,7 +51,6 @@
     <bundle>wrap:mvn:jakarta.jms/jakarta.jms-api/${jakarta.jms-api.version}</bundle>
     <bundle>wrap:mvn:jakarta.json.bind/jakarta.json.bind-api/${jakarta.json.bind-api.version}</bundle>
     <bundle>wrap:mvn:jakarta.json/jakarta.json-api/${jakarta.json-api.version}</bundle>
-    <bundle>wrap:mvn:jakarta.jws/jakarta.jws-api/${jakarta.jws-api.version}</bundle>
     <!-- From Geronimo
     <bundle>wrap:mvn:jakarta.mail/jakarta.mail-api/${jakarta.mail-api.version}</bundle>
     -->
@@ -73,9 +72,5 @@
     -->
     <bundle>wrap:mvn:org.apache.tomcat/tomcat-websocket-api/${tomcat.version}</bundle>
     <bundle>wrap:mvn:jakarta.ws.rs/jakarta.ws.rs-api/${jakarta.ws.rs-api.version}</bundle>
-    <bundle>wrap:mvn:jakarta.xml.bind/jakarta.xml.bind-api/${jakarta.xml.bind-api.version}</bundle>
-    <bundle>wrap:mvn:jakarta.xml.soap/jakarta.xml.soap-api/${jakarta.xml.soap-api.version}</bundle>
-    <bundle>wrap:mvn:jakarta.xml.ws/jakarta.xml.ws-api/${jakarta.xml.ws-api.version}</bundle>
-
   </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,10 @@
 
   <groupId>org.apache.tomee</groupId>
   <artifactId>jakartaee-api-parent</artifactId>
-  <version>10.0.2-SNAPSHOT</version>
+  <version>11.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Apache TomEE :: Jakarta EE 10 Full API :: Parent</name>
+  <name>Apache TomEE :: Jakarta EE 11 Full API :: Parent</name>
 
   <modules>
     <module>api</module>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -31,9 +31,11 @@
     <name>Apache TomEE :: Jakarta EE 11 Full API :: Signature Tests</name>
 
     <properties>
-        <tck.file>jakarta-jakartaeetck-10.0.6.zip</tck.file>
-        <tck.url>https://download.eclipse.org/jakartaee/platform/10/${tck.file}</tck.url>
-        <tck.sha256>c3c7e37ceeb4073d3cbf70826563ea1c37ad85fd9ff180f7e3330e2cd73b934d</tck.sha256>
+        <tck.file>jakarta-jakartaeetck-11.0.1.zip</tck.file>
+        <tck.url>https://download.eclipse.org/jakartaee/platform/11/jakarta-jakartaeetck-11.0.1.zip</tck.url>
+        <tck.sha256>b2c0ad6db0514b75ff612dd7d855a3976c8ae9f240a3b690a684f61bf503bead</tck.sha256>
+        
+        <sigdir>${project.build.directory}/jakartaeetck/src/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest</sigdir>
     </properties>
 
     <build>
@@ -115,7 +117,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.annotation.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.annotation.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.annotation.**</packages>
@@ -128,23 +130,23 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.batch.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.batch.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.batch.**</packages>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>check-jakarta-decorator</id>
+                        <id>check-jakarta-data</id>
                         <goals>
                             <goal>check</goal>
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.decorator.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.data.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
-                            <packages>jakarta.decorator.**</packages>
+                            <packages>jakarta.data.**</packages>
                         </configuration>
                     </execution>
                     <execution>
@@ -154,7 +156,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.ejb.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.ejb.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.ejb.**</packages>
@@ -167,7 +169,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.el.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.el.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.el.**</packages>
@@ -180,7 +182,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.enterprise.concurrent.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.enterprise.concurrent.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.enterprise.concurrent.**</packages>
@@ -193,7 +195,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.enterprise.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.enterprise.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.enterprise</packages>
@@ -207,25 +209,12 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.faces.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.faces.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.faces.**</packages>
                         </configuration>
                     </execution>-->
-                    <execution>
-                        <id>check-jakarta-inject</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.inject.sig</sigfile>
-                            <action>strictcheck</action>
-                            <failOnError>true</failOnError>
-                            <packages>jakarta.inject.**</packages>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>check-jakarta-interceptor</id>
                         <goals>
@@ -233,7 +222,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.interceptor.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.interceptor.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.interceptor.**</packages>
@@ -246,7 +235,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.jms.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.jms.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.jms.**</packages>
@@ -259,7 +248,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.json.bind.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.json.bind.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.json.bind.**</packages>
@@ -272,7 +261,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.json.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.json.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.json</packages>
@@ -286,7 +275,7 @@
 <!--                        </goals>-->
 <!--                        <configuration>-->
 <!--                            <ignoreJDKClass>true</ignoreJDKClass>-->
-<!--                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.mail.sig</sigfile>-->
+<!--                            <sigfile>${sigdir}/jakarta.mail.sig</sigfile>-->
 <!--                            <action>strictcheck</action>-->
 <!--                            <failOnError>true</failOnError>-->
 <!--                            <packages>jakarta.mail.**</packages>-->
@@ -299,7 +288,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.persistence.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.persistence.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.persistence.**</packages>
@@ -312,7 +301,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.resource.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.resource.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.resource.**</packages>
@@ -325,7 +314,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.security.auth.message.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.security.auth.message.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.security.auth.message.**</packages>
@@ -338,7 +327,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.security.enterprise.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.security.enterprise.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.security.enterprise.**</packages>
@@ -351,7 +340,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.security.jacc.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.security.jacc.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.security.jacc.**</packages>
@@ -365,7 +354,7 @@
 <!--                        </goals>-->
 <!--                        <configuration>-->
 <!--                            <ignoreJDKClass>true</ignoreJDKClass>-->
-<!--                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.servlet.jsp.jstl.sig</sigfile>-->
+<!--                            <sigfile>${sigdir}/jakarta.servlet.jsp.jstl.sig</sigfile>-->
 <!--                            <action>strictcheck</action>-->
 <!--                            <failOnError>true</failOnError>-->
 <!--                            <packages>jakarta.servlet.jsp.jstl.**</packages>-->
@@ -378,7 +367,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.servlet.jsp.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.servlet.jsp.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.servlet.jsp.**</packages>
@@ -391,7 +380,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.servlet.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.servlet.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.servlet</packages>
@@ -404,7 +393,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.transaction.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.transaction.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.transaction.**</packages>
@@ -417,7 +406,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.validation.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.validation.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.validation.**</packages>
@@ -430,7 +419,7 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.websocket.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.websocket.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.websocket.**</packages>
@@ -443,52 +432,12 @@
                         </goals>
                         <configuration>
                             <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.ws.rs.sig</sigfile>
+                            <sigfile>${sigdir}/jakarta.ws.rs.sig</sigfile>
                             <action>strictcheck</action>
                             <failOnError>true</failOnError>
                             <packages>jakarta.ws.rs.**</packages>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>check-jakarta-xml-soap</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.xml.soap.sig</sigfile>
-                            <action>strictcheck</action>
-                            <failOnError>true</failOnError>
-                            <packages>jakarta.xml.soap.**</packages>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>check-jakarta-xml-ws</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <ignoreJDKClass>true</ignoreJDKClass>
-                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.xml.ws.sig</sigfile>
-                            <action>strictcheck</action>
-                            <failOnError>true</failOnError>
-                            <packages>jakarta.xml.ws.**</packages>
-                        </configuration>
-                    </execution>
-                    <!-- CORBA Stuff not required for Web Profile ... -->
-<!--                    <execution>-->
-<!--                        <id>check-javax-rmi</id>-->
-<!--                        <goals>-->
-<!--                            <goal>check</goal>-->
-<!--                        </goals>-->
-<!--                        <configuration>-->
-<!--                            <ignoreJDKClass>true</ignoreJDKClass>-->
-<!--                            <sigfile>${project.build.directory}/jakartaeetck/src/com/sun/ts/tests/signaturetest/signature-repository/javax.rmi.sig</sigfile>-->
-<!--                            <action>strictcheck</action>-->
-<!--                            <failOnError>true</failOnError>-->
-<!--                            <packages>javax.rmi.**</packages>-->
-<!--                        </configuration>-->
-<!--                    </execution>-->
                 </executions>
             </plugin>
         </plugins>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -21,14 +21,14 @@
     <parent>
         <groupId>org.apache.tomee</groupId>
         <artifactId>jakartaee-api-parent</artifactId>
-        <version>10.0.2-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakartaee-api-tck</artifactId>
-    <version>10.0.2-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Apache TomEE :: Jakarta EE 10 Full API :: Signature Tests</name>
+    <name>Apache TomEE :: Jakarta EE 11 Full API :: Signature Tests</name>
 
     <properties>
         <tck.file>jakarta-jakartaeetck-10.0.6.zip</tck.file>


### PR DESCRIPTION
sigtests are passing so far. I removed specs that aren't tied to Jakarta EE platform anymore and added Jakarta Data (see https://jakarta.ee/specifications/platform/11/jakarta-platform-spec-11.0#changes-in-jakarta-ee-11)

Would greatly appreciate if someone with more experience could take a look. Once this is merged I'd suggest we branch off EE10